### PR TITLE
Port and warn for base.EMPTYSTRING

### DIFF
--- a/Lib/base64.py
+++ b/Lib/base64.py
@@ -30,6 +30,11 @@ __all__ = [
 
 
 bytes_types = (bytes, bytearray)  # Types acceptable as binary data
+EMPTYSTRING = ''
+from warnings import warnpy2x
+warnpy2x("base64.EMPTYSTRING is not supported in 3.x", 
+                  "introduce an alias", stacklevel=2)
+del warnpy2x
 
 def _bytes_from_decode_data(s):
     if isinstance(s, str):

--- a/Lib/test/test_base64.py
+++ b/Lib/test/test_base64.py
@@ -5,6 +5,7 @@ import os
 from array import array
 from test.support import os_helper
 from test.support import script_helper
+from test.support import warnings_helper 
 
 
 class LegacyBase64TestCase(unittest.TestCase):
@@ -120,6 +121,11 @@ class BaseXYTestCase(unittest.TestCase):
         bytes_data = data + padding # Make sure cast works
         int_data = memoryview(bytes_data).cast('I')
         self.assertEqual(f(int_data), f(bytes_data))
+
+    def test_py2x_base64_empty_string(self):
+        expected = "base64.EMPTYSTRING is not supported in 3.x: introduce an alias"
+        with warnings_helper.check_py2x_warnings(expected, DeprecationWarning):
+            from base64 import EMPTYSTRING
 
 
     def test_b64encode(self):

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -6847,7 +6847,7 @@ wrap_cmpfunc(PyObject *self, PyObject *args, void *wrapped)
     int res = 0;
     PyObject *other;
 
-      if (Py_Py2xWarningFlag &&
+    if (Py_Py2xWarningFlag &&
         PyErr_WarnEx_WithFix(PyExc_Py2xWarning, "the cmp method is not supported in 3.x",
         "you can either provide your own alternative or use a third party library with a "
          "backwards compatible fix", 1) < 0) {


### PR DESCRIPTION
Following the comments [here](https://github.com/softdevteam/pygrate2/pull/18), I forward ported `base64.EMPTYSTRING"