### PR TITLE
Port next to py3.x

### DIFF
--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -1247,6 +1247,29 @@ class BuiltinTest(unittest.TestCase):
         self.assertRaises(StopIteration, next, it)
         self.assertEqual(next(it, 42), 42)
 
+    def test_dunder_next(self):
+        it = iter(range(2))
+        self.assertEqual(it.next(), 0)
+        self.assertEqual(it.next(), 1)
+        self.assertRaises(StopIteration, it.next)
+        self.assertRaises(StopIteration, it.next)
+
+        class Iter(object):
+            def __iter__(self):
+                return self
+            def __next__(self):
+                raise StopIteration
+
+        it = iter(Iter())
+
+        def gen():
+            yield 1
+            return
+
+        it = gen()
+        self.assertEqual(it.next(), 1)
+        self.assertRaises(StopIteration, it.next)
+
     def test_oct(self):
         self.assertEqual(oct(100), '0o144')
         self.assertEqual(oct(-100), '-0o144')

--- a/Lib/test/test_generators.py
+++ b/Lib/test/test_generators.py
@@ -897,7 +897,7 @@ From the Iterators list, about the types of these things.
 >>> type(i)
 <class 'generator'>
 >>> [s for s in dir(i) if not s.startswith('_')]
-['close', 'gi_code', 'gi_frame', 'gi_running', 'gi_suspended', 'gi_yieldfrom', 'send', 'throw']
+['close', 'gi_code', 'gi_frame', 'gi_running', 'gi_suspended', 'gi_yieldfrom', 'next', 'send', 'throw']
 >>> from test.support import HAVE_DOCSTRINGS
 >>> print(i.__next__.__doc__ if HAVE_DOCSTRINGS else 'Implement next(self).')
 Implement next(self).

--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -1049,7 +1049,7 @@ class APIMismatchTest(unittest.TestCase):
 
     def test_RawIOBase_pyio_in_io_match(self):
         """Test that c RawIOBase class has all pyio RawIOBase methods"""
-        mismatch = support.detect_api_mismatch(io.RawIOBase, pyio.RawIOBase)
+        mismatch = support.detect_api_mismatch(io.RawIOBase, pyio.RawIOBase, ignore=('next',))
         self.assertEqual(mismatch, set(), msg='C RawIOBase does not have all Python RawIOBase methods')
 
 

--- a/Lib/test/test_py2xwarn.py
+++ b/Lib/test/test_py2xwarn.py
@@ -2,9 +2,11 @@ import unittest
 import sys
 from test.support.warnings_helper import check_py2x_warnings
 import warnings
+from test import test_support
 
 if not sys.py2x_warning:
     raise unittest.SkipTest('%s must be run with the -2 flag' % __name__)
+
 
 class TestPy2xWarnings(unittest.TestCase):
 
@@ -13,3 +15,16 @@ class TestPy2xWarnings(unittest.TestCase):
 
     def assertNoWarning(self, _, recorder):
         self.assertEqual(len(recorder.warnings), 0)
+
+    def test_next(self):
+        marks = [65, 71, 68, 74, 61]
+        iterator_marks = iter(marks)
+        expected = "The attribute 'x.next' is not supported in 3.x: use 'x.__next__'."
+
+        with check_py2x_warnings() as w:
+            self.assertWarning(iterator_marks.next(), w, expected)
+            w.reset()
+            self.assertNoWarning(iterator_marks.__next__(), w)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -7044,6 +7044,24 @@ wrap_next(PyObject *self, PyObject *args, void *wrapped)
 }
 
 static PyObject *
+wrap_next_warn(PyObject *self, PyObject *args, void *wrapped)
+{
+    unaryfunc func = (unaryfunc)wrapped;
+    PyObject *res;
+
+    if (PyErr_WarnPy2x("The attribute 'x.next' is not supported in 3.x", 
+                               "use 'x.__next__'.", 1) < 0)
+        return NULL;
+
+    if (!check_num_args(args, 0))
+        return NULL;
+    res = (*func)(self);
+    if (res == NULL && !PyErr_Occurred())
+        PyErr_SetNone(PyExc_StopIteration);
+    return res;
+}
+
+static PyObject *
 wrap_descr_get(PyObject *self, PyObject *args, void *wrapped)
 {
     descrgetfunc func = (descrgetfunc)wrapped;
@@ -8075,6 +8093,8 @@ static slotdef slotdefs[] = {
            "__iter__($self, /)\n--\n\nImplement iter(self)."),
     TPSLOT("__next__", tp_iternext, slot_tp_iternext, wrap_next,
            "__next__($self, /)\n--\n\nImplement next(self)."),
+    TPSLOT("next", tp_iternext, slot_tp_iternext, wrap_next_warn,
+           "x.next() <==> next(x)"),
     TPSLOT("__get__", tp_descr_get, slot_tp_descr_get, wrap_descr_get,
            "__get__($self, instance, owner, /)\n--\n\nReturn an attribute of instance, which is of type owner."),
     TPSLOT("__set__", tp_descr_set, slot_tp_descr_set, wrap_descr_set,


### PR DESCRIPTION
This PR introduces `x.next()` which is equivalent to `x.__next__()`.