### PR TITLE
Add warning for build-in function map and filter

### DIFF
--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -782,7 +782,7 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
                                                  env=env, cwd=cwd)
         if stderr is None and not expected_config['verbose']:
             stderr = ""
-        if stderr is not None and not ignore_stderr:
+        if stderr is not None and not ignore_stderr and expected_config["py2x_warning"] != 1:
             self.assertEqual(err.rstrip(), stderr)
         try:
             configs = json.loads(out)

--- a/Lib/test/test_py2xwarn.py
+++ b/Lib/test/test_py2xwarn.py
@@ -15,6 +15,16 @@ class TestPy2xWarnings(unittest.TestCase):
 
     def assertNoWarning(self, _, recorder):
         self.assertEqual(len(recorder.warnings), 0)
+    
+    def test_map_warning(self):
+        with check_py2x_warnings() as w:
+            expected = "map(...) returns map object in 3.x, not a list. Change to list(map(...))"
+            self.assertWarning(map(lambda x: x, [1, 2, 3]), w, expected)
+    
+    def test_filter_warning(self):
+        with check_py2x_warnings() as w:
+            expected = "filter(...) returns filter object in 3.x, not a list. Change to list(filter(...))"
+            self.assertWarning(filter(lambda x: x%2==0, [1, 2, 3]), w, expected)
 
     def test_next(self):
         marks = [65, 71, 68, 74, 61]

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -549,6 +549,13 @@ filter_vectorcall(PyObject *type, PyObject * const*args,
     lz->func = Py_NewRef(args[0]);
     lz->it = it;
 
+    if (Py_Py2xWarningFlag && PyErr_WarnEx(
+        PyExc_Py2xWarning,
+        "filter(...) returns filter object in 3.x, not a list. Change to list(filter(...))",
+        2) < 0){
+            return NULL;
+    }
+
     return (PyObject *)lz;
 }
 
@@ -1249,7 +1256,6 @@ map_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
            "map() must have at least two arguments.");
         return NULL;
     }
-
     iters = PyTuple_New(numargs-1);
     if (iters == NULL)
         return NULL;
@@ -1314,6 +1320,13 @@ map_vectorcall(PyObject *type, PyObject * const*args,
     }
     lz->iters = iters;
     lz->func = Py_NewRef(args[0]);
+
+    if (Py_Py2xWarningFlag && PyErr_WarnEx(
+        PyExc_Py2xWarning,
+        "map(...) returns map object in 3.x, not a list. Change to list(map(...))",
+        2) < 0){
+            return NULL;
+    }
 
     return (PyObject *)lz;
 }


### PR DESCRIPTION
Modified map_vectorcall in bltinmodule.c, which warn user about behavior change of map in 3.x (return map object)
<img width="800" height="130" alt="image" src="https://github.com/user-attachments/assets/d167a6cf-cf58-422d-bd02-3f408dde5610" />
Modified filter_vectorcall in bltinmodule.c, which warn user about behavior change of filter in 3.x (return filter object)
<img width="1389" height="165" alt="image" src="https://github.com/user-attachments/assets/f3229d88-07a8-49c7-befe-4244db2b29f8" />

Both advice user to use list to wrap result.


Add test cases in test_py2xwarn