### PR TITLE
Add warning for dict.keys, values, items

### DIFF
--- a/Lib/test/test_py2xwarn.py
+++ b/Lib/test/test_py2xwarn.py
@@ -25,6 +25,22 @@ class TestPy2xWarnings(unittest.TestCase):
             self.assertWarning(iterator_marks.next(), w, expected)
             w.reset()
             self.assertNoWarning(iterator_marks.__next__(), w)
+            
+    def test_dict(self):
+        expected = [
+            "dict_values() returns a view in 3.x, not a list. Use list(dict_values()) instead"
+            "dict_keys() returns a view in 3.x, not a list. Use list(dict_keys()) instead"
+            "dict_items() returns a view in 3.x, not a list. Use list(dict_items()) instead"
+        ]
+        test = {"a":1}
+        
+        with check_py2x_warnings() as w:
+            self.assertWarning(test.values(), w, expected[0])
+            w.reset()
+            self.assertWarning(test.keys(), w, expected[1])
+            w.reset()
+            self.assertWarning(test.items(), w, expected[2])
+            
 
 if __name__ == '__main__':
     unittest.main()

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -4589,6 +4589,11 @@ _PyDictView_New(PyObject *dict, PyTypeObject *type)
         return NULL;
     Py_INCREF(dict);
     dv->dv_dict = (PyDictObject *)dict;
+    if (Py_Py2xWarningFlag && PyErr_WarnFormat(PyExc_Py2xWarning, 1, 
+        "%s() returns a view in 3.x, not a list. Use list(%s()) instead",
+        type->tp_name, type->tp_name) < 0){
+            return NULL;
+    }
     _PyObject_GC_TRACK(dv);
     return (PyObject *)dv;
 }


### PR DESCRIPTION
Add warning to warn user about behavior changes that keys, values, items will return a view instead of list, and advice user to wrap it with list()

Add test cases 