### PR TITLE
Add warning for dict.keys(),values(), items().sort

### DIFF
--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -5081,11 +5081,38 @@ static PyObject* dictkeys_reversed(_PyDictViewObject *dv, PyObject *Py_UNUSED(ig
 PyDoc_STRVAR(reversed_keys_doc,
 "Return a reverse iterator over the dict keys.");
 
+/*No-Operation for dictview.sort(), Just warn under -2 flag*/
+static PyObject *
+dictview_noop(PyObject *self, PyObject *args, PyObject *kwargs)
+{
+    if (Py_Py2xWarningFlag){
+        const char *type = Py_TYPE(self)->tp_name;
+        if (PyErr_WarnFormat(PyExc_Py2xWarning, 1,
+            "%s.sort: in Python 3, %s() returns an iterable view; "
+            "views do not support .sort(). Use list(%s()).sort() or sorted(%s()).",
+            type, type, type, type) < 0) {
+            return NULL;
+        }
+        Py_RETURN_NONE;
+    }
+    else{
+        return PyErr_Format(PyExc_AttributeError,
+                            "'%s' object has no attribute 'sort'",
+                            Py_TYPE(self)->tp_name);
+    }
+}
+
 static PyMethodDef dictkeys_methods[] = {
     {"isdisjoint",      (PyCFunction)dictviews_isdisjoint,  METH_O,
      isdisjoint_doc},
     {"__reversed__",    _PyCFunction_CAST(dictkeys_reversed),    METH_NOARGS,
      reversed_keys_doc},
+    {"reverse",    _PyCFunction_CAST(dictkeys_reversed),    METH_NOARGS,
+     reversed_keys_doc},
+    {"sort",
+     _PyCFunction_CAST(dictview_noop),
+     METH_VARARGS | METH_KEYWORDS,
+     PyDoc_STR("No-op: warn that dict key object have no .sort attribute")},
     {NULL,              NULL}           /* sentinel */
 };
 
@@ -5133,6 +5160,15 @@ dictkeys_reversed(_PyDictViewObject *dv, PyObject *Py_UNUSED(ignored))
 {
     if (dv->dv_dict == NULL) {
         Py_RETURN_NONE;
+    }
+    if (Py_Py2xWarningFlag){
+        const char *type = Py_TYPE(dv)->tp_name;
+        if (PyErr_WarnFormat(PyExc_Py2xWarning, 1,
+            "%s.reverse: in Python 3, %s() returns an iterable view; "
+            "views do not support .reverse(). Use list(%s()).reverse() or reversed(list(%s())) or list(%s().__reversed__())",
+            type, type, type, type, type) < 0) {
+            return NULL;
+        }
     }
     return dictiter_new(dv->dv_dict, &PyDictRevIterKey_Type);
 }
@@ -5192,6 +5228,12 @@ static PyMethodDef dictitems_methods[] = {
      isdisjoint_doc},
     {"__reversed__",    (PyCFunction)dictitems_reversed,    METH_NOARGS,
      reversed_items_doc},
+    {"reverse",    (PyCFunction)dictitems_reversed,    METH_NOARGS,
+     reversed_items_doc},
+    {"sort",
+     _PyCFunction_CAST(dictview_noop),
+     METH_VARARGS | METH_KEYWORDS,
+     PyDoc_STR("No-op: warn that dict items object have no .sort attribute")},
     {NULL,              NULL}           /* sentinel */
 };
 
@@ -5273,6 +5315,12 @@ PyDoc_STRVAR(reversed_values_doc,
 static PyMethodDef dictvalues_methods[] = {
     {"__reversed__",    (PyCFunction)dictvalues_reversed,    METH_NOARGS,
      reversed_values_doc},
+    {"reverse",    (PyCFunction)dictvalues_reversed,    METH_NOARGS,
+     reversed_values_doc},
+    {"sort",
+     _PyCFunction_CAST(dictview_noop),
+     METH_VARARGS | METH_KEYWORDS,
+     PyDoc_STR("No-op: warn that dict values object have no .sort attribute")},
     {NULL,              NULL}           /* sentinel */
 };
 


### PR DESCRIPTION
Add a warning for calls to dict.keys().sort(), dict.values().sort(), and dict.items().sort(), informing users that in Python 3 these methods return iterable views rather than lists.
 
Add warning for call of .reverse() for keys(), values(), items(). Add attribute reverse() and point to `__reversed__()`.

Since directly calling .sort() on a dict view object in Python 3 would otherwise raise an AttributeError, the implementations of _PyObject_GetMethod and PyObject_GenericGetAttr were modified to detect this pattern. Instead of failing, they now return a dummy function that issues a warning and performs no action.

In Python 2, dict.keys(), dict.values(), and dict.items() returned lists, so calling .sort() directly was valid and modified the returned list in place. Replicating this behavior in Python 3 would require converting between view objects and lists, which add complexity.

Therefore, I decide to just warn the user about the semantic change without attempting to preserve the original sorting behavior.

<img width="1767" height="499" alt="image" src="https://github.com/user-attachments/assets/16a04e20-33d9-4d56-be9f-99219e8fb75b" />
