### PR TITLE
Add warning for truncate(0)

### DIFF
--- a/Lib/test/test_py2xwarn.py
+++ b/Lib/test/test_py2xwarn.py
@@ -3,6 +3,8 @@ import sys
 from test.support.warnings_helper import check_py2x_warnings
 import warnings
 from test import test_support
+import tempfile
+
 
 if not sys.py2x_warning:
     raise unittest.SkipTest('%s must be run with the -2 flag' % __name__)
@@ -25,6 +27,16 @@ class TestPy2xWarnings(unittest.TestCase):
             self.assertWarning(iterator_marks.next(), w, expected)
             w.reset()
             self.assertNoWarning(iterator_marks.__next__(), w)
+            
+    def test_truncate0(self):
+        expected = "Calling truncate(0) on text stream without seek(0)" + \
+        " may produce inconsistent results. Use seek(0) before truncate(0)"
+        with check_py2x_warnings(("", Py2xWarning)) as w:
+            with tempfile.NamedTemporaryFile("w+", encoding="utf-8", delete=True) as f:
+                f.write("test")
+                f.truncate(0)
+                self.assertWarning((), w, expected)
+            
 
 if __name__ == '__main__':
     unittest.main()

--- a/Modules/_io/textio.c
+++ b/Modules/_io/textio.c
@@ -2846,6 +2846,26 @@ _io_TextIOWrapper_truncate_impl(textio *self, PyObject *pos)
         return NULL;
     Py_DECREF(res);
 
+    if(Py_Py2xWarningFlag){
+        if (pos != Py_None && PyLong_Check(pos)) {
+            if (PyLong_AsLong(pos) == 0) {
+                PyObject *sres = PyObject_CallMethod((PyObject *)self, "seek", "i", 0);
+                if (sres == NULL)
+                    return NULL;
+                Py_DECREF(sres);
+                if (PyErr_WarnEx(PyExc_Py2xWarning,
+                    "Calling truncate(0) on text stream without seek(0)"
+                    " may produce inconsistent results. Use seek(0) before truncate(0)",
+                    2
+                    ) < 0){
+                        return NULL;
+                }
+            }
+            
+        }
+        
+    }
+
     return PyObject_CallMethodOneArg(self->buffer, &_Py_ID(truncate), pos);
 }
 


### PR DESCRIPTION
Add warning for truncate(0), and perform an implicit seek(0) in truncate method under -2 flag. Warn user to use seek(0) before truncate(0) to avoid potential different result.

<img width="1357" height="205" alt="image" src="https://github.com/user-attachments/assets/09722c35-2350-46ff-84d1-9da607947d7e" />
