### PR TITLE
Add warning for removed byte feature .format

### DIFF
--- a/Lib/test/test_py2xwarn.py
+++ b/Lib/test/test_py2xwarn.py
@@ -46,6 +46,11 @@ class TestPy2xWarnings(unittest.TestCase):
                 f.write("test")
                 f.truncate(0)
                 self.assertWarning((), w, expected)
+    
+    def test_byteformat(self):
+        expected = "bytes.format() is not supported in Python 3, use str.format() and encode() instead."
+        with check_py2x_warnings(("", Py2xWarning)) as w:
+            self.assertWarning(b"te{}".format("st"), w, expected)
             
 
 if __name__ == '__main__':

--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -115,6 +115,55 @@ _Py_COMP_DIAG_POP
     return (PyObject *) op;
 }
 
+static PyObject *
+bytes_format(PyObject *self, PyObject *args, PyObject *kwargs)
+{
+    if (Py_Py2xWarningFlag){
+        if (PyErr_WarnEx(
+            PyExc_Py2xWarning,
+            "bytes.format() is not supported in Python 3, "
+            "use str.format() and encode() instead.",
+            1) < 0) {
+            return NULL;
+        }
+
+        if (!PyBytes_Check(self)) {
+            PyErr_SetString(PyExc_TypeError, "expected bytes as input");
+            return NULL;
+        }
+
+        Py_ssize_t size = PyBytes_GET_SIZE(self);
+        const char *buf = PyBytes_AS_STRING(self);
+
+        PyObject *fmt_str = PyUnicode_DecodeASCII(buf, size, "surrogateescape");
+        PyObject *format_method = PyObject_GetAttrString(fmt_str, "format");
+
+        PyObject *result_str = PyObject_Call(format_method, args, kwargs);
+        Py_DECREF(format_method);
+        Py_DECREF(fmt_str);
+
+        PyObject *result_bytes = PyUnicode_AsEncodedString(
+            result_str,
+            "ascii",
+            "surrogateescape"
+        );
+
+        if (!PyBytes_Check(result_bytes)) {
+            PyErr_SetString(PyExc_TypeError, "expected bytes as output");
+            Py_DECREF(result_str);
+            return NULL;
+        }
+
+        Py_DECREF(result_str);
+        return result_bytes;
+    }
+    else{
+        return PyErr_Format(PyExc_AttributeError,
+            "'%s' object has no attribute 'format'",
+            Py_TYPE(self)->tp_name);
+    }
+}
+
 PyObject *
 PyBytes_FromStringAndSize(const char *str, Py_ssize_t size)
 {
@@ -2553,6 +2602,8 @@ bytes_methods[] = {
     BYTES_TRANSLATE_METHODDEF
     {"upper", stringlib_upper, METH_NOARGS, _Py_upper__doc__},
     STRINGLIB_ZFILL_METHODDEF
+    {"format", (PyCFunction)bytes_format, METH_VARARGS | METH_KEYWORDS,
+     PyDoc_STR("format(*args, **kwargs) -> bytes")},
     {NULL,     NULL}                         /* sentinel */
 };
 


### PR DESCRIPTION
byte in py3 doesn't have `format` method attribute, which it has in py2.  Add a format method attribute to the byteobject that give warning under py2xflag and perform similarly as in python2. 

<img width="1202" height="153" alt="image" src="https://github.com/user-attachments/assets/e6dad1d1-b446-4127-88b4-60d118bd4a9b" />
